### PR TITLE
Change the rendering logic of TabGroup component

### DIFF
--- a/client/components/App.vue
+++ b/client/components/App.vue
@@ -85,7 +85,7 @@
             openTab: function () {
                 this._addTab({
                     tabGroupId: 'app',
-                    tabContent: {name: 'New Tab', query: ''},
+                    tabContent: {name: 'New Tab'},
                     tabViewComponent: 'argo-new-tab'
                 })
             },

--- a/client/components/CommandPallete.vue
+++ b/client/components/CommandPallete.vue
@@ -15,7 +15,7 @@
     }
 </script>
 
-<style language="scss">
+<style lang="scss" scoped>
     @import "variables";
 
     .command-pallete {

--- a/client/components/NewTab.vue
+++ b/client/components/NewTab.vue
@@ -62,7 +62,7 @@
             </div>-->
             <div class="search-input-wrapper flex-row flex-grow-1">
                 <span class="placeholder text-muted">argo://</span>
-                <input type="text" class="flex-grow-1 input-text" :value="tabContent.query" @input="updateQuery">
+                <input type="text" class="flex-grow-1 input-text" :value="query">
             </div>
         </div>
         <div class="flex-grow-1 content-wrapper">
@@ -87,6 +87,11 @@
         computed: {
             ...mapGetters(['listOfPrototypes'])
         },
+        data: function () {
+            return {
+                query: ''
+            }
+        },
         methods: {
             ...mapActions({
                 _addTab: types.ADD_TAB,
@@ -102,15 +107,6 @@
                             tabViewComponent: 'argo-dummy'
                         })
                     })
-            },
-            updateQuery: function(e) {
-                this.$store.commit(types.UPDATE_TAB_CONTENT, {
-                    tabGroupId: 'app',
-                    tabIndex: this.tabIndex,
-                    tabContent: {
-                        query: e.target.value
-                    }
-                })
             }
         },
         props: ['tabContent', 'tabIndex'],

--- a/client/components/TabGroup/TabGroup.vue
+++ b/client/components/TabGroup/TabGroup.vue
@@ -14,11 +14,12 @@
             </component>
             <button :class="newTabButtonClass" @click="openTab">+</button>
         </div>
-        <argo-tab-content   v-if="tabs[activeTab]"
-                            :tabIndex="activeTab"
+        <argo-tab-content   v-for="(tab, index) in tabs"
+                            :style="{display: isActiveTab(index) ? '' : 'none'}"
+                            :tabIndex="index"
                             :tabViewClass="tabViewClass"
-                            :tabViewComponent="tabs[activeTab].tabViewComponent"
-                            :tabContent="tabs[activeTab].tabContent">
+                            :tabViewComponent="tab.tabViewComponent"
+                            :tabContent="tab.tabContent">
         </argo-tab-content>
     </div>
 </template>


### PR DESCRIPTION
The TabGroup component now renders all the tab views instead of just the active one. The inactive tabs are hidden using `display:none`. The v-for will take care of maintaining separate ui state (scroll, data, etc.) for each tab. The UPDATE_TAB_CONTENT mutation is untouched.